### PR TITLE
Issue with loading model when running eval.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -352,7 +352,7 @@ class ClaimBusterModel:
                     files.append(os.fsdecode(fstr))
 
             if len(ret_ar) == 0 and len(files) > 0:
-                return scan_loc + '/'
+                return int([x for x in scan_loc.split("/") if x][-1]), scan_loc.rstrip("/") + '/'
 
             ret_ar.sort()
             return int(ret_ar[-1]), os.path.join(scan_loc, ret_ar[-1]) + '/'


### PR DESCRIPTION
The function get_last_save(...) only returns one value when a model directory is specified even though the return value is always expected to  be a 2-tuple. Also, if the user includes a trailing slash for a model directory this seems to cause issues. Proposed are fixes for both of these issues.