### PR TITLE
Use epoch to name final training epoch directory.

### DIFF
--- a/advtrain.py
+++ b/advtrain.py
@@ -90,7 +90,7 @@ def main():
 
         tf.logging.info('Training complete.')
         if (FLAGS.advtrain_steps - 1) % FLAGS.model_save_interval != 0:
-            cb_model.save_model(sess, FLAGS.advtrain_steps)
+            cb_model.save_model(sess, epoch)
             tf.logging.info('Final model saved.')
 
         sess.close()


### PR DESCRIPTION
If you have 18 epochs saved and then train for 32, the previous 32nd epoch that was saved will get overwritten since FLAGS.advtrain_steps will also be set to 32.

Also, not sure if the behavior of line 88 is correct. If you resume training, that is start_epoch != 0, do you still need to add 1 to the current epoch?