### PR TITLE
Add tpu usage at colab notebook

### DIFF
--- a/bidirectional_lstm/bilstm-notebook.ipynb
+++ b/bidirectional_lstm/bilstm-notebook.ipynb
@@ -85,7 +85,17 @@
         "from tensorflow.keras.layers import Embedding, LSTM, Dense, Bidirectional\n",
         "from tensorflow.keras.preprocessing.text import Tokenizer\n",
         "from tensorflow.keras.preprocessing.sequence import pad_sequences\n",
-        "from tensorflow.keras.utils import to_categorical"
+        "from tensorflow.keras.utils import to_categorical\n",
+        "\n",
+        "try:\n",
+        "    tpu = tf.distribute.cluster_resolver.TPUClusterResolver()  # TPU detection\n",
+        "    print('Running on TPU ', tpu.cluster_spec().as_dict()['worker'])\n",
+        "except ValueError:\n",
+        "    raise BaseException('ERROR: Not connected to a TPU runtime; please see the previous cell in this notebook for instructions!')\n",
+        "\n",
+        "tf.config.experimental_connect_to_cluster(tpu)\n",
+        "tf.tpu.experimental.initialize_tpu_system(tpu)\n",
+        "tpu_strategy = tf.distribute.experimental.TPUStrategy(tpu)"
       ],
       "execution_count": null,
       "outputs": [
@@ -449,20 +459,23 @@
         "    x_train, x_test = X_train[train_index], X_train[test_index]\n",
         "    y_train, y_test = Y_train[train_index], Y_train[test_index]\n",
         "    \n",
-        "    # instantiate model\n",
-        "    print(\"x_train dimensions: \", x_train.shape)\n",
-        "    print(\"y_train dimensions: \", y_train.shape)\n",
-        "    model = create_model(max_words, embedding_dim, max_len, embedding_matrix)\n",
-        "    \n",
-        "    # train model\n",
-        "    print(\"Training ....\")\n",
-        "    history = model.fit(x_train, y_train, epochs = 15)\n",
-        "    \n",
-        "    # print fold classification report\n",
-        "    y_hat = model.predict(x_test, verbose = 0)\n",
-        "    cfs_probs = y_hat[:, 1]\n",
-        "    y_hat_classes = tf.argmax(y_hat, axis=1).numpy()\n",
-        "    y_test_classes = tf.argmax(y_test, axis=1).numpy()\n",
+        "\n",
+        "    # Enter TPU env:\n",
+        "    with tpu_strategy.scope():\n",
+        "        # instantiate model\n",
+        "        print(\"x_train dimensions: \", x_train.shape)\n",
+        "        print(\"y_train dimensions: \", y_train.shape)\n",
+        "        model = create_model(max_words, embedding_dim, max_len, embedding_matrix)\n",
+        "        \n",
+        "        # train model\n",
+        "        print(\"Training ....\")\n",
+        "        history = model.fit(x_train, y_train, epochs = 15)\n",
+        "        \n",
+        "        # print fold classification report\n",
+        "        y_hat = model.predict(x_test, verbose = 0)\n",
+        "        cfs_probs = y_hat[:, 1]\n",
+        "        y_hat_classes = tf.argmax(y_hat, axis=1).numpy()\n",
+        "        y_test_classes = tf.argmax(y_test, axis=1).numpy()\n",
         "    \n",
         "    print(classification_report(y_test_classes, y_hat_classes, ))\n",
         "    print(\"Average precision: \", compute_average_precision(y_test_classes, y_hat_classes))\n",
@@ -540,7 +553,8 @@
         "id": "C63G_pf8upNO"
       },
       "source": [
-        "full_model = create_model(max_words, embedding_dim, max_len, embedding_matrix)"
+        "with tpu_strategy.scope():\n",
+        "    full_model = create_model(max_words, embedding_dim, max_len, embedding_matrix)"
       ],
       "execution_count": null,
       "outputs": []
@@ -551,7 +565,8 @@
         "id": "wHFHL5PyuzS5"
       },
       "source": [
-        "history = full_model.fit(X_train, Y_train, epochs = 14)"
+        "with tpu_strategy.scope():\n",
+        "    history = full_model.fit(X_train, Y_train, epochs = 14)"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
When training the BiLSTM model I notice significant improvement on training time when using the tpu runtime, I added the instructions for using in the notebook.

In the future, maybe we can add the same support for the transformer model notebook after adapting the training code to colab so it can use the tpu runtime.